### PR TITLE
Add podspec

### DIFF
--- a/RBStoryboardLink.podspec
+++ b/RBStoryboardLink.podspec
@@ -1,0 +1,20 @@
+Pod::Spec.new do |s|
+  s.name         = 'RBStoryboardLink'
+  s.version      = '0.0.1'
+  s.summary      = 'Makes transitioning between storyboards possible.'
+  s.homepage     = 'https://github.com/rob-brown/RBStoryboardLink'
+  s.license      = { 
+    :type => 'MIT', 
+    :file => 'LICENSE' 
+  }
+  s.author       = 'Robert Brown'
+  s.source       = { 
+      :git => 'https://github.com/rob-brown/RBStoryboardLink.git', 
+      :commit => 'HEAD'
+  }
+  s.platform     = :ios, '5.0'
+  s.source_files = 'RBStoryboardLink.{h,m}'
+  s.public_header_files = 'RBStoryboardLink.h'
+  s.frameworks = 'UIKit'
+  s.requires_arc = true
+end


### PR DESCRIPTION
I’ve recently added [`RBStoryboardLink`](https://github.com/CocoaPods/Specs/commit/51a01fdf6fd000e6b9dbcd2b82cdbd4c2d220bf6) to the [CocoaPods](https://github.com/CocoaPods/CocoaPods) package manager repo.

CocoaPods is a tool for managing dependencies for OS X and iOS Xcode projects and provides a central repository for iOS/OS X libraries. This makes adding libraries to a project and updating them extremely easy and it will help users to resolve dependencies of the libraries they use.

However, `RBStoryboardLink` doesn't have any version tags. I’ve added the current HEAD as version 0.0.1, but a version tag will make dependency resolution much easier.

[Semantic version](http://semver.org) tags (instead of plain commit hashes/revisions) allow for [resolution of cross-dependencies](https://github.com/CocoaPods/Specs/wiki/Cross-dependencies-resolution-example).

This pull request adds the podspec to the repository, so that it can be versioned together with `RBStoryboardLink`.
