### PR TITLE
View not loading after memory warning.

### DIFF
--- a/RBStoryboardLink.m
+++ b/RBStoryboardLink.m
@@ -135,6 +135,14 @@
     self.wantsFullScreenLayout = scene.wantsFullScreenLayout;
 }
 
+- (void)viewDidLoad {
+    [super viewDidLoad];
+    
+    // adds the scene's view
+    [self.view addSubview:[self.scene view]];
+    [self.scene didMoveToParentViewController:self];
+}
+
 - (BOOL)shouldAutorotateToInterfaceOrientation:(UIInterfaceOrientation)toInterfaceOrientation {
     
     // The linked scene defines the rotation. 


### PR DESCRIPTION
Fixes an issue where the scene's view does not get reloaded after being cleaned up during a memory warning.
