### PR TITLE
Limit method forwarding to specific method

### DIFF
--- a/Classes/RBStoryboardLink.m
+++ b/Classes/RBStoryboardLink.m
@@ -282,27 +282,17 @@
 
 // The following methods are important to get unwind segues to work properly.
 
-- (BOOL)respondsToSelector:(SEL)aSelector {
-    if (aSelector != @selector(canPerformUnwindSegueAction:fromViewController:withSender:))
-        return [super respondsToSelector:aSelector];
-    
-    return ([super respondsToSelector:aSelector] ||
-            [self.scene respondsToSelector:aSelector]);
+- (BOOL)canPerformUnwindSegueAction:(SEL)action fromViewController:(UIViewController *)fromViewController withSender:(id)sender {
+    return [self.scene canPerformUnwindSegueAction:action fromViewController:fromViewController withSender:sender];
 }
 
 - (NSMethodSignature *)methodSignatureForSelector:(SEL)aSelector {
-    if (aSelector != @selector(canPerformUnwindSegueAction:fromViewController:withSender:))
-        return [super methodSignatureForSelector:aSelector];
-    
     return ([super methodSignatureForSelector:aSelector]
             ?:
             [self.scene methodSignatureForSelector:aSelector]);
 }
 
 - (void)forwardInvocation:(NSInvocation *)anInvocation {
-    if ([anInvocation selector] != @selector(canPerformUnwindSegueAction:fromViewController:withSender:))
-        return [super forwardInvocation:anInvocation];
-    
     if ([self.scene respondsToSelector:[anInvocation selector]])
         [anInvocation invokeWithTarget:self.scene];
     else


### PR DESCRIPTION
I think the method forwarding to child view controllers in _RBStoryBoardLink.m_ should be limited to  `canPerformUnwindSegueAction:fromViewController:withSender:` since simply forwarding every method is not very clean and can cause problems in at least one specific case.
Imagine one of the child view controllers implements an unwind action but overrides `canPerformUnwindAction:...` to return _NO_ in some specific cases when it wants the unwind to be handled by a VC further up the stack. When the request arrives at the link VC it will call `respondsToSelector:` with the unwind action on itself and, since the call is forwarded down to the child VC, will respond with _YES_. The system will then attempt to perform the unwind on the link VC instead of going further up the chain.
