### PR TITLE
Fixed demo app to build on iPhone 5s and iPhone 6 (64 bit).

### DIFF
--- a/LinkedStoryboards/LinkedStoryboards.xcodeproj/project.pbxproj
+++ b/LinkedStoryboards/LinkedStoryboards.xcodeproj/project.pbxproj
@@ -283,7 +283,7 @@
 			isa = PBXProject;
 			attributes = {
 				CLASSPREFIX = LS;
-				LastUpgradeCheck = 0500;
+				LastUpgradeCheck = 0600;
 				ORGANIZATIONNAME = "Robert Brown";
 				TargetAttributes = {
 					E1FBA006182EF33D00E3ECB8 = {
@@ -468,9 +468,11 @@
 				CLANG_WARN_EMPTY_BODY = YES;
 				CLANG_WARN_ENUM_CONVERSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				COPY_PHASE_STRIP = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_OPTIMIZATION_LEVEL = 0;
@@ -480,6 +482,7 @@
 				);
 				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
 				GCC_VERSION = com.apple.compilers.llvm.clang.1_0;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
 				GCC_WARN_UNDECLARED_SELECTOR = YES;
 				GCC_WARN_UNINITIALIZED_AUTOS = YES;
@@ -501,11 +504,14 @@
 				CLANG_WARN_EMPTY_BODY = YES;
 				CLANG_WARN_ENUM_CONVERSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				COPY_PHASE_STRIP = YES;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_VERSION = com.apple.compilers.llvm.clang.1_0;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
 				GCC_WARN_UNDECLARED_SELECTOR = YES;
 				GCC_WARN_UNINITIALIZED_AUTOS = YES;
@@ -548,7 +554,6 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 54298183A1DD452C828174B7 /* Pods-UI Tests.xcconfig */;
 			buildSettings = {
-				ARCHS = "$(ARCHS_STANDARD_INCLUDING_64_BIT)";
 				BUNDLE_LOADER = "$(BUILT_PRODUCTS_DIR)/LinkedStoryboards.app/LinkedStoryboards";
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";
@@ -588,7 +593,6 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 54298183A1DD452C828174B7 /* Pods-UI Tests.xcconfig */;
 			buildSettings = {
-				ARCHS = "$(ARCHS_STANDARD_INCLUDING_64_BIT)";
 				BUNDLE_LOADER = "$(BUILT_PRODUCTS_DIR)/LinkedStoryboards.app/LinkedStoryboards";
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";

--- a/LinkedStoryboards/Podfile
+++ b/LinkedStoryboards/Podfile
@@ -7,5 +7,5 @@ pod 'RBStoryboardLink', :path => '../RBStoryboardLink.podspec'
 # It is important that we don't include KIF in the main app.
 # Some of the categories cause the UI to appear unresponsive.
 target 'UI Tests', :exclusive => true do
-    pod 'KIF', '~> 2.0', :inhibit_warnings => true
+    pod 'KIF', '~> 3.0', :inhibit_warnings => true
 end

--- a/LinkedStoryboards/Podfile.lock
+++ b/LinkedStoryboards/Podfile.lock
@@ -1,9 +1,11 @@
 PODS:
-  - KIF (2.0.0)
-  - RBStoryboardLink (0.1.0)
+  - KIF (3.0.8):
+    - KIF/XCTest
+  - KIF/XCTest (3.0.8)
+  - RBStoryboardLink (0.1.1)
 
 DEPENDENCIES:
-  - KIF (~> 2.0)
+  - KIF (~> 3.0)
   - RBStoryboardLink (from `../RBStoryboardLink.podspec`)
 
 EXTERNAL SOURCES:
@@ -11,7 +13,7 @@ EXTERNAL SOURCES:
     :path: ../RBStoryboardLink.podspec
 
 SPEC CHECKSUMS:
-  KIF: 45369d4a30f5ac140be8267f31f637b9d2a239f4
-  RBStoryboardLink: ab20204dad0e4752720abdee4cb317c67ea0afbc
+  KIF: 2db5e8cf59136dd1267d49cca0d55883389b09d3
+  RBStoryboardLink: d870832266eede14cb45533e7a10e4fbd5b011ce
 
 COCOAPODS: 0.33.1


### PR DESCRIPTION
The Podfile dependency to KIF testing framework was updated to get v >= 3.0 thus this it the one with fixed 64 compatibility. This change may also be a part of #38. RBStoryboardLink seem to work now as desired in the demo app.

Project file has been also changed to be Xcode 6 compatible and don't produce build warnings.