### PR TITLE
Fix to retrieve modal presentation attributes

### DIFF
--- a/Classes/RBStoryboardModalSegue.m
+++ b/Classes/RBStoryboardModalSegue.m
@@ -26,6 +26,15 @@
 
 @implementation RBStoryboardModalSegue
 
+- (id)initWithIdentifier:(NSString *)identifier source:(UIViewController *)source destination:(UIViewController *)destination {
+    if (self = [super initWithIdentifier:identifier source:source destination:destination]) {
+        self.presentationStyle = destination.modalPresentationStyle;
+        self.transitionStyle = destination.modalTransitionStyle;
+        
+    };
+    return self;
+}
+
 - (void)perform {
 
     [self.destinationViewController setModalPresentationStyle:self.presentationStyle];


### PR DESCRIPTION
Hi, here's a change to retrieve the view controller modal attributes.
I've not found a way to set the presentation style and I think the attributes were not set.