### PR TITLE
supportedInterfaceOrientations method not returning the correct type

### DIFF
--- a/Classes/RBStoryboardLink.m
+++ b/Classes/RBStoryboardLink.m
@@ -257,7 +257,7 @@
     return [self.scene shouldAutorotate];
 }
 
-- (NSUInteger)supportedInterfaceOrientations {
+- (UIInterfaceOrientationMask)supportedInterfaceOrientations {
 
     // The linked scene defines supported orientations.
     return [self.scene supportedInterfaceOrientations];


### PR DESCRIPTION
supportedInterfaceOrientations method in RBStoryboardLink.h was returning NSUInteger instead of UIInterfaceOrientationMask
